### PR TITLE
Edits to the discussion section

### DIFF
--- a/content/04.discussion.md
+++ b/content/04.discussion.md
@@ -1,47 +1,52 @@
 ## Discussion
 
 <!-- Discuss why vg is doing better -->
-vg was the most accurate SV genotyper in our benchmarks, overall.
-These results show that variant calling benefits from variant-aware read mapping, a finding consistent with previous graph-based studies[@tag:vgnbt; @tag:bakeoff; @doi:10.1038/s41588-018-0316-4; @tag:graphtyper; @tag:bayestyper].
+Overall, vg was the most accurate SV genotyper in our benchmarks.
+These results show that variant calling benefits from variant-aware read mapping, a finding consistent with previous studies[@tag:vgnbt; @tag:bakeoff; @doi:10.1038/s41588-018-0316-4; @tag:graphtyper; @tag:bayestyper].
 <!-- Other advantages: SV representation, unified variant calling. -->
-In addition to its variant-aware read mapping, vg offers additional advantages.
-Its unified framework calls and scores different variant types simultaneously.
-For variant interpretation in particular, a comprehensive and unified characterization of the genomic variation will be extremely valuable. 
-Variation graphs that contain known SNVs, indels and SVs could serve as a richer reference for large scale projects that use short-read sequencing.
-More and more large-scale projects are sequencing the genomes of thousands or hundreds of thousands of individuals and could benefit from such a framework, e.g. the Pancancer Analysis of Whole Genomes[@url:https://dcc.icgc.org/pcawg], the Genomics England initiative[@url:https://www.genomicsengland.co.uk], and the TOPMed consortium[@url:https://www.nhlbiwgs.org/].
-In contrast to incorporating SVs into a linear pan-genome reference via alt contigs, the graph structure can represent SVs as succinctly as possible.
-Alt contigs often contain redundant sequence resulting in increased mapping ambiguity and involves custom pipelines and non-standard metadata formats linking the contigs back to the reference.
-These issues make the alt contigs difficult to use, maintain, and scale as SV catalogs continue to expand.
+In addition to variant-aware mapping, vg uses a unified framework to call and score different variant types simultaneously. 
 
+Variation graphs that contain known SNVs, indels and SVs could serve as a richer reference for large scale genomics projects.
+More and more large-scale projects are using low cost short-read technologies to sequence the genomes of thousands to hundreds of thousands of individuals (e.g. the Pancancer Analysis of Whole Genomes[@url:https://dcc.icgc.org/pcawg], the Genomics England initiative[@url:https://www.genomicsengland.co.uk], and the TOPMed consortium[@url:https://www.nhlbiwgs.org/]). 
+Our method substantially improves on the state of the art for how accurately known SVs can be genotyped with this type of data.
+Thus, it expands the scope of genomic variation that can be assayed at such a large scale with low cost sequencing. 
+
+[//]: # (In my opinion, we could cut the two sentences about BayesTyper. We compared against four other genotyping algorithms, it seems a little arbitrary to emphasize our advantage against one other one on one aspect of performance--especially since this subject matter is mirrored in the results section)
 <!-- Input data quality: "sequence-resolved", break-point fine-tuning. -->
-Our method requires near-breakpoint resolution in the variant library used to construct the graph.
-Simulations have shown that SV genotyping with vg is robust to errors of as much as 10 bp in breakpoint location.
-Variants with higher uncertainty in the breakpoint location, for example discovered through read coverage analysis, cannot be safely added to the graph.
-By being robust to some errors in the breakpoint location, vg was more accurate in real data compared to the other genome graph method tested, BayesTyper, which assumes sequence-resolved variants as input.
-Of note, vg is also capable of fine-tuning SV breakpoints using an augmentation step that modifies the graph based on the read alignment.
-While this augmentation approach was developed to discover novel SNVs and indels, simulations showed that it is capable of correcting erroneous SV breakpoints (Figure {@fig:simerror-bkpt} and Table {@tbl:simerror-bkpt}).
+A particular advantage of our method is that it does not require exact breakpoint resolution in the variant library.
+Our simulations showed that vg's SV genotyping algorithm is robust to errors of as much as 10 bp in breakpoint location.
+However, there is an upper limit.
+vg cannot accurately genotype variants with much higher uncertainty in the breakpoint location (like those discovered through read coverage analysis).
+vg's robustness to breakpoint errors helped it achieve higher accuracy in real data than BayesTyper, the other genome graph-based method we tested.
+Unlike vg, BayesTyper relies on exact matches between reads and graph paths, which makes it sensitive to breakpoint uncertainty.
+Of note, vg is also capable of fine-tuning SV breakpoints by augmenting the graph with differences observed in read alignments.
+Simulations showed that this approach can usually correct small errors in SV breakpoints (Figure {@fig:simerror-bkpt} and Table {@tbl:simerror-bkpt}).
 
 <!-- Already superior but will only get better with new vg dev -->
 The vg toolkit is under active development.
-Read mapping is an area of constant improvement, in terms of both computational efficiency and accuracy.
-One technique under development is the application of haplotype information for the improvement of read mapping and variant calling. 
-We believe that this technique stands to benefit SV genotyping with vg, as haplotype information might enable inference at the scale of SVs when using short reads.
+Read mapping is an area of constant improvement in terms of both computational efficiency and accuracy.
+One technique under development is the integration of haplotype information into the process of read mapping and variant calling. 
+We believe vg's SV genotyping algorithm stands to benefit from this technique. 
+Haplotype information can be used to limit the variant search space and provide stronger priors on variant combinations.
+Faster mapping also helps increase the scale on which this method can be used practically.
 
 In our benchmarks, other methods were superior in a handful datasets and situations, primarily when genotyping deletions.
-However, even in most of these cases, vg had the best accuracy when evaluating only the presence or absence of each variant call.
+However, even in most of these cases, vg had the best accuracy when evaluating only the presence or absence of the variants.
 This suggests that the performance shortfall can be attributed to the genotyping algorithm rather than the mapping pipeline.
 We hope to address these issues in a future release.
 
 <!-- Benefits of de novo assemblies -->
 Our results suggest that constructing a graph from de novo assembly alignment instead of a VCF leads to better SV genotyping.
-High quality de novo assemblies for human are becoming more and more common, for example from optimized mate-pair libraries[@tag:denmark] or long-read sequencing[@doi:10.1038/nbt.4060].
-For an optimal representation of genomic variation, we expect the future graphs to include information from the alignment of numerous de novo assemblies.
-We are presently working on scaling our pipeline to human-sized genome assemblies.
-Aligning assembled contigs to existing variation graphs, like to ones created from SVs catalogs, is still experimental but could generate a genome graph augmented with both existing variant databases and new high-quality assemblies.
+High quality de novo assemblies for human are becoming more and more common due to improvements in technologies like optimized mate-pair libraries[@tag:denmark] and long-read sequencing[@doi:10.1038/nbt.4060].
+We expect the future graphs to include information from the alignment of numerous de novo assemblies.
+We are presently working on scaling our assembly-based pipeline to human-sized genome assemblies.
+Another challenge is creating genome graphs that integrate assemblies with variant-based data resources.
+One possible approach is to progressively align assembled contigs into variation graphs constructed from variant libraries.
+Methods for doing so are still experimental.
 
 ## Conclusion
 
 In this study, the vg toolkit was compared to existing SV genotypers across several high-quality SV catalogs.
-We showed that its implementation of variation graphs lead to a better SV genotyping compared to methods that rely on read mapping to a linear reference genome or a variation graph approach that requires exact sequence-resolved variants.
-This work introduces a flexible strategy to integrate the growing number of SVs being discovered with higher resolution technologies into the unified framework of variation graphs.
-This study also shows the benefit of starting directly from de novo assemblies rather than variant catalogs to integrate SVs in genome graphs.
+We showed that its method of mapping reads to a variation graph leads to better SV genotyping compared to other state of the art methods.
+This work introduces a flexible strategy to integrate the growing number of SVs being discovered with higher resolution technologies into a unified framework of genome inference.
+This study also shows the benefit of directly utilizing de novo assemblies rather than variant catalogs to integrate SVs in genome graphs.

--- a/content/04.discussion.md
+++ b/content/04.discussion.md
@@ -21,6 +21,8 @@ For example, we are interested in evaluating how genotyping SVs together with SN
 The same methods used for genotyping known variants in this work can also be extended to call novel variants by first augmenting the graph with edits from the mapped reads.
 This approach, which was used only in the breakpoint fine-tuning portion of this work, could be further used to study small variants around and nested within SVs.
 Novel SVs could be called by augmenting the graph with long-read mappings.
+vg is entirely open source, and there is a growing community of developers and users working together to constantly improve it.
+We expect this collaboration to continue to foster increases in the speed, accuracy and applicability of methods based on pan-genome graphs in the years ahead.
 
 <!-- Benefits of de novo assemblies -->
 Our results suggest that constructing a graph from de novo assembly alignment instead of a VCF leads to better SV genotyping.

--- a/content/04.discussion.md
+++ b/content/04.discussion.md
@@ -3,37 +3,24 @@
 <!-- Discuss why vg is doing better -->
 Overall, vg was the most accurate SV genotyper in our benchmarks.
 These results show that variant calling benefits from variant-aware read mapping, a finding consistent with previous studies[@tag:vgnbt; @tag:bakeoff; @doi:10.1038/s41588-018-0316-4; @tag:graphtyper; @tag:bayestyper].
-<!-- Other advantages: SV representation, unified variant calling. -->
-In addition to variant-aware mapping, vg uses a unified framework to call and score different variant types simultaneously. 
+More and more large-scale projects are using low cost short-read technologies to sequence the genomes of thousands to hundreds of thousands of individuals (e.g. the Pancancer Analysis of Whole Genomes[@url:https://dcc.icgc.org/pcawg], the Genomics England initiative[@url:https://www.genomicsengland.co.uk], and the TOPMed consortium[@url:https://www.nhlbiwgs.org/]).
+We believe pangenome graph-based approaches will improve both how efficiently SVs can be represented, and how accurately they can be genotyped with this type of data.
 
-Variation graphs that contain known SNVs, indels and SVs could serve as a richer reference for large scale genomics projects.
-More and more large-scale projects are using low cost short-read technologies to sequence the genomes of thousands to hundreds of thousands of individuals (e.g. the Pancancer Analysis of Whole Genomes[@url:https://dcc.icgc.org/pcawg], the Genomics England initiative[@url:https://www.genomicsengland.co.uk], and the TOPMed consortium[@url:https://www.nhlbiwgs.org/]). 
-Our method substantially improves on the state of the art for how accurately known SVs can be genotyped with this type of data.
-Thus, it expands the scope of genomic variation that can be assayed at such a large scale with low cost sequencing. 
-
-[//]: # (In my opinion, we could cut the two sentences about BayesTyper. We compared against four other genotyping algorithms, it seems a little arbitrary to emphasize our advantage against one other one on one aspect of performance--especially since this subject matter is mirrored in the results section)
 <!-- Input data quality: "sequence-resolved", break-point fine-tuning. -->
 A particular advantage of our method is that it does not require exact breakpoint resolution in the variant library.
 Our simulations showed that vg's SV genotyping algorithm is robust to errors of as much as 10 bp in breakpoint location.
 However, there is an upper limit.
 vg cannot accurately genotype variants with much higher uncertainty in the breakpoint location (like those discovered through read coverage analysis).
-vg's robustness to breakpoint errors helped it achieve higher accuracy in real data than BayesTyper, the other genome graph-based method we tested.
-Unlike vg, BayesTyper relies on exact matches between reads and graph paths, which makes it sensitive to breakpoint uncertainty.
 Of note, vg is also capable of fine-tuning SV breakpoints by augmenting the graph with differences observed in read alignments.
 Simulations showed that this approach can usually correct small errors in SV breakpoints (Figure {@fig:simerror-bkpt} and Table {@tbl:simerror-bkpt}).
 
 <!-- Already superior but will only get better with new vg dev -->
-The vg toolkit is under active development.
-Read mapping is an area of constant improvement in terms of both computational efficiency and accuracy.
-One technique under development is the integration of haplotype information into the process of read mapping and variant calling. 
-We believe vg's SV genotyping algorithm stands to benefit from this technique. 
-Haplotype information can be used to limit the variant search space and provide stronger priors on variant combinations.
-Faster mapping also helps increase the scale on which this method can be used practically.
-
-In our benchmarks, other methods were superior in a handful datasets and situations, primarily when genotyping deletions.
-However, even in most of these cases, vg had the best accuracy when evaluating only the presence or absence of the variants.
-This suggests that the performance shortfall can be attributed to the genotyping algorithm rather than the mapping pipeline.
-We hope to address these issues in a future release.
+vg uses a unified framework to call and score different variant types simultaneously.
+In this work, we only considered graphs containing certain types of SVs, but the same methods can be extended to a broader range of graphs.
+For example, we are interested in evaluating how genotyping SVs together with SNPs and small indels using a combined graph effects the accuracy of studying either alone.
+The same methods used for genotyping known variants in this work can also be extended to call novel variants by first augmenting the graph with edits from the mapped reads.
+This approach, which was used only in the breakpoint fine-tuning portion of this work, could be further used to study small variants around and nested within SVs.
+Novel SVs could be called by augmenting the graph with long-read mappings.
 
 <!-- Benefits of de novo assemblies -->
 Our results suggest that constructing a graph from de novo assembly alignment instead of a VCF leads to better SV genotyping.
@@ -43,6 +30,7 @@ We are presently working on scaling our assembly-based pipeline to human-sized g
 Another challenge is creating genome graphs that integrate assemblies with variant-based data resources.
 One possible approach is to progressively align assembled contigs into variation graphs constructed from variant libraries.
 Methods for doing so are still experimental.
+
 
 ## Conclusion
 


### PR DESCRIPTION
I made a few moderately substantial changes to content here. First, I cut the material on alt contigs. For one, it more or less parroted some material in the introduction. I also felt like it wasn't an emphasis of the actual experiments we did--I don't think any of them were comparing to alt contig based methods.

I also cut some content about variant interpretation and consistent representation of variation. Mostly, I just felt like that material was underdeveloped. Some of the points were hard for me to understand. If we decide to go back on this decision, I do think the points would need to be fleshed out to be interpretable by a general audience.

I have some concerns about section talking about using haplotypes. It doesn't have a lot of detail about how haplotypes would be used for mapping or for variant calling. Without that, it more or less amounts to "if mapping were better variant calling would be better". That feels kinda weak to me. I think this section is another one that should either be shored up or cut.

I also have a comment in the text recommending that we cut some points about BayesTyper, but y'all can read it there.